### PR TITLE
chore: configure direnv for environment management

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,7 @@
 # .envrc
+
+# Load the Nix environment
+use flake
+
+# Load environment variables from the .env file
 dotenv_if_exists

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 dist/
 .env
+
+.direnv/


### PR DESCRIPTION
Add flake support to .envrc to enable Nix environment loading and
ignore the .direnv directory to prevent tracking local environment
artifacts in version control.
